### PR TITLE
add start_date field, change example format of test_budget

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -226,8 +226,8 @@ If you are not yet authorized to run a campaign (the campaign's `approval_status
             {
                 "campaign_id": 2,
                 "traffic_types": ["Display", "Email"],
-                "test_budget": 100,
-                "start_date": "2018-08-13",
+                "start_date": "2016-01-01",
+                "test_budget": "100",
                 "request_detail": "Target Audience, Placement, etc",
                 "success_criteria": "EPC, Conversion Rate, etc"
             }
@@ -1237,6 +1237,7 @@ There are a lot of filtering capabilities for this report. Most of the columns r
 ## Campaign Approval Lite (Campaign Approval Minimal)
 - response_comment: This is a comment (string) - A comment regarding the approval/denial
 - traffic_types: [Display, Email] (array) - The traffic types requested to be ran
+- start_date: 2018-08-03 (string) - The requested start date
 - test_budget: 100 (string) - The requested number of test leads or clicks
 - request_detail: Target Audience, Placement, etc (string) - Details of how the campaign will be ran
 - success_criteria: EPC, Conversion Rate, etc (string) - How the test will be judged to be successful


### PR DESCRIPTION
The start_date field was missing, so adding that. Also changing the example data format of test_budget to be a string, to be consistent with what the field type accepts.

Dredd tests pass.